### PR TITLE
Multiple alerts not creating as expected

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ data "template_file" "metricalerttemplate" {
 
 resource "azurerm_template_deployment" "custom_alert" {
   template_body       = "${data.template_file.metricalerttemplate.rendered}"
-  name                = "${var.app_insights_name}"
+  name                = "${var.alert_name}"
   resource_group_name = "${var.resourcegroup_name}"
   deployment_mode     = "Incremental"
 


### PR DESCRIPTION
When defining multiple alerts - they were not creating in Azure as expected but not throwing any errors in Terraform output. Tested in Sandbox first (`cmc-sandbox`) - just the alerts.

Tested: https://github.com/hmcts/cmc-shared-infrastructure/blob/master/alerts.tf

https://build.platform.hmcts.net/job/HMCTS_CMC/job/cmc-shared-infrastructure/job/master/

Now seeing expected resources in portal.