### PR TITLE
Provide variable for optional alert creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The following parameters are required by this module
 - `location` The location of the Azure data center.
 - `alert_name` The name of the alert to create.
 - `alert_desc` A description of the alert.
+- `enabled` true/false flag.
 - `app_insights_query` The custom query to execute against the logs. See https://docs.microsoft.com/en-us/azure/application-insights/app-insights-analytics .
 - `action_group_name` The name of the action group to invoke when the alert is triggered.
 - `custom_email_subject` The subject of the email sent to the email IDs specified in the action group. (If there are no email IDs in the action group, this must still be defined but can be set to the empty string.)
@@ -35,7 +36,7 @@ This module provides no outputs.
 
 ## Usage
 
-The following example shows how to use the module to create an Azure alert for an application insights instance.
+The following example shows how to use the module to create an (enabled) Azure alert for an application insights instance.
 
 ```terraform
 module "messy-dudes-alert" {

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ The following parameters are required by this module
 - `location` The location of the Azure data center.
 - `alert_name` The name of the alert to create.
 - `alert_desc` A description of the alert.
-- `enabled` true/false flag.
 - `app_insights_query` The custom query to execute against the logs. See https://docs.microsoft.com/en-us/azure/application-insights/app-insights-analytics .
 - `action_group_name` The name of the action group to invoke when the alert is triggered.
 - `custom_email_subject` The subject of the email sent to the email IDs specified in the action group. (If there are no email IDs in the action group, this must still be defined but can be set to the empty string.)
@@ -22,6 +21,7 @@ The following parameters are required by this module
 
 The following parameters are optional
 
+- `enabled` true/false flag. Default is true
 - `frequency_in_minutes` The number of minutes between inspections. That is, a value of `5` means the alert will be queried every 5 minutes, for a frequency of 12/minute. Default is `5`.
 - `time_window_in_minutes` The previous window of time over which to execute the query, in minutes. This is often the same value as `frequency_in_minutes`. Default is `5`.
 - `severity_level` The severity of this alert. Allowed values are from `0` to `4`. Default is `3`.

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,7 @@ data "template_file" "metricalerttemplate" {
 }
 
 resource "azurerm_template_deployment" "custom_alert" {
+  count               = "${var.enabled ? 1 : 0}"
   template_body       = "${data.template_file.metricalerttemplate.rendered}"
   name                = "${var.alert_name}"
   resource_group_name = "${var.resourcegroup_name}"
@@ -15,7 +16,6 @@ resource "azurerm_template_deployment" "custom_alert" {
   parameters = {
     alertName                = "${var.alert_name}"
     alertDesc                = "${var.alert_desc}"
-    alertEnabled             = "${var.enabled}"
     appInsightsName          = "${var.app_insights_name}"
     location                 = "${var.location}"
     triggerThresholdOperator = "${var.trigger_threshold_operator}"

--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,7 @@ resource "azurerm_template_deployment" "custom_alert" {
   parameters = {
     alertName                = "${var.alert_name}"
     alertDesc                = "${var.alert_desc}"
+    alertEnabled             = "${var.enabled}"
     appInsightsName          = "${var.app_insights_name}"
     location                 = "${var.location}"
     triggerThresholdOperator = "${var.trigger_threshold_operator}"

--- a/templates/Alert.json
+++ b/templates/Alert.json
@@ -8,10 +8,6 @@
     "alertDesc": {
       "type": "string"
     },
-    "alertEnabled": {
-      "type": "string",
-      "defaultValue": "true"
-    },
     "appInsightsName": {
       "type": "string"
     },
@@ -66,7 +62,7 @@
       },
       "properties": {
         "description": "[parameters('alertDesc')]",
-        "enabled": "[parameters('alertEnabled')]",
+        "enabled": "true",
         "skuType": "L1",
         "source": {
           "query": "[parameters('appInsightsQuery')]",

--- a/templates/Alert.json
+++ b/templates/Alert.json
@@ -8,6 +8,10 @@
     "alertDesc": {
       "type": "string"
     },
+    "alertEnabled": {
+      "type": "string",
+      "defaultValue": "true"
+    },
     "appInsightsName": {
       "type": "string"
     },
@@ -62,7 +66,7 @@
       },
       "properties": {
         "description": "[parameters('alertDesc')]",
-        "enabled": "true",
+        "enabled": "[parameters('alertEnabled')]",
         "skuType": "L1",
         "source": {
           "query": "[parameters('appInsightsQuery')]",

--- a/variables.tf
+++ b/variables.tf
@@ -58,3 +58,8 @@ variable trigger_threshold_operator {
 variable trigger_threshold {
   description = "The threshold at which to trigger the alert, with respect to the trigger_threshold_operator"
 }
+
+variable "enabled" {
+  description = "Whether alert is enabled or not"
+  default = "true"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -60,6 +60,6 @@ variable trigger_threshold {
 }
 
 variable "enabled" {
-  description = "Whether alert is enabled or not"
+  description = "Whether alert is created or not"
   default = "true"
 }


### PR DESCRIPTION
~Straight-forward use case example: only enable alerting for production.~ Do not create an alert if module provides `enabled=false`

Keeping default as true for backwards compatibility