### PR TITLE
Revert "DTSPO:7157 add tags"

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,6 @@ The following parameters are required by this module
 - `custom_email_subject` The subject of the email sent to the email IDs specified in the action group. (If there are no email IDs in the action group, this must still be defined but can be set to the empty string.)
 - `trigger_threshold` The threshold at which to trigger the alert, with respect to the `trigger_threshold_operator`.
 
-The following parameters are required for resource tagging. see https://github.com/hmcts/azure-policy/tree/master/policies/tagging
-- `businessArea`  Enter Business Area this application belongs to
-- `builtFrom`  Name of the GitHub repository this application is being built from
-- `application`  Enter name of the application
-- `environment`  Enter name of the environment to deploy
-
 The following parameters are optional
 
 - `enabled` true/false flag. Default is true

--- a/main.tf
+++ b/main.tf
@@ -27,9 +27,5 @@ resource "azurerm_template_deployment" "custom_alert" {
     customEmailSubject       = "${var.custom_email_subject}"
     appInsightsQuery         = "${var.app_insights_query}"
     actionGroupRg            = "${local.action_group_rg}"
-    environment              = "${var.environment}"
-    application              = "${var.application}"
-    builtFrom                = "${var.builtFrom}"
-    businessArea             = "${var.businessArea}"
   }
 }

--- a/templates/Alert.json
+++ b/templates/Alert.json
@@ -49,18 +49,6 @@
     },
     "appInsightsQuery": {
       "type": "string"
-    },
-    "application": {
-      "type": "string"
-    },
-    "builtFrom": {
-      "type": "string"
-    },
-    "businessArea": {
-      "type": "string"
-    },
-    "environment": {
-      "type": "string"
     }
   },
   "resources": [
@@ -70,11 +58,7 @@
       "type": "microsoft.insights/scheduledqueryrules",
       "location": "[parameters('location')]",
       "tags": {
-        "[concat('hidden-link:', resourceId('microsoft.insights/components', parameters('appInsightsName')))]": "Resource",
-        "application": "[parameters('application')]",
-        "builtFrom": "[parameters('builtFrom')]",
-        "businessArea": "[parameters('businessArea')]",
-        "environment": "[parameters('environment')]"
+        "[concat('hidden-link:', resourceId('microsoft.insights/components', parameters('appInsightsName')))]": "Resource"
       },
       "properties": {
         "description": "[parameters('alertDesc')]",

--- a/variables.tf
+++ b/variables.tf
@@ -63,17 +63,3 @@ variable "enabled" {
   description = "Whether alert is created or not"
   default = "true"
 }
-
-variable "environment" {
-  description = "Enter name of the environment to deploy"
-}
-variable "application" {
-  description = "Enter name of the application"
-}
-
-variable "builtFrom"{
-  description = "Name of the GitHub repository this application is being built from."
-}
-variable "businessArea"{
-  description = "Enter Business Area this application belongs to"
-}


### PR DESCRIPTION
Reverts hmcts/cnp-module-metric-alert#7
This was a breaking change and isn't the standard pattern for handling common_tags in other cnp modules