### PR TITLE
Revert "Update main.tf"

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ data "template_file" "metricalerttemplate" {
   template = "${file("${path.module}/templates/Alert.json")}"
 }
 
-resource "azurerm_resource_group_template_deployment" "custom_alert" {
+resource "azurerm_template_deployment" "custom_alert" {
   count               = "${var.enabled ? 1 : 0}"
   template_body       = "${data.template_file.metricalerttemplate.rendered}"
   name                = "${var.alert_name}"


### PR DESCRIPTION
May need to review this change further - causing other pipelines to fail. @damongreen123 can you review changes required?


```

[2023-02-06T18:04:45.181Z] │ Error: Unsupported argument

[2023-02-06T18:04:45.181Z] │ 

[2023-02-06T18:04:45.181Z] │   on .terraform/modules/bad-response-codes-alert/main.tf line 11, in resource "azurerm_resource_group_template_deployment" "custom_alert":

[2023-02-06T18:04:45.181Z] │   11:   template_body       = "${data.template_file.metricalerttemplate.rendered}"

[2023-02-06T18:04:45.181Z] │ 

[2023-02-06T18:04:45.181Z] │ An argument named "template_body" is not expected here.

[2023-02-06T18:04:45.181Z] ╵

[2023-02-06T18:04:45.181Z] ╷

[2023-02-06T18:04:45.181Z] │ Error: Unsupported argument

[2023-02-06T18:04:45.181Z] │ 

[2023-02-06T18:04:45.181Z] │   on .terraform/modules/bad-response-codes-alert/main.tf line 16, in resource "azurerm_resource_group_template_deployment" "custom_alert":

[2023-02-06T18:04:45.181Z] │   16:   parameters = {

[2023-02-06T18:04:45.181Z] │ 

[2023-02-06T18:04:45.181Z] │ An argument named "parameters" is not expected here.
```